### PR TITLE
fix(59): molerobot hat ungültige achseneinstellung in der projektdatei

### DIFF
--- a/project/whacAmole.project
+++ b/project/whacAmole.project
@@ -8,7 +8,7 @@
          <MachType></MachType>
          <Link Parent="zero" />
          <Model>kr210-r2700.robot</Model>
-         <Position Pos="{X 0.00, Y 0.00, Z 0.00, A 0.00, B 0.00, C 0.00}" />
+         <Position Pos="{X 0.00, Y 0.00, Z 1250.00, A 0.00, B 0.00, C 0.00}" />
          <RobRoot Pos="{X 0.00, Y 0.00, Z 0.00, A 0.00, B -0.00, C 0.00}" />
          <AxisPos Pos="{A1 0.00, A2 -90.00, A3 90.00, A4 0.00, A5 90.00, A6 0.00}" />
          <ToolData Value="{X -500.00, Y 0.00, Z 50.00, A 0.00, B 180.00, C 0.00}" />
@@ -25,7 +25,7 @@
          <Model>KR210-R2700.robot</Model>
          <Position Pos="{X 4500.00, Y 0.00, Z 0.00, A 180.00, B 0.00, C 0.00}" />
          <RobRoot Pos="{X 0.00, Y 0.00, Z 0.00, A 0.00, B -0.00, C 0.00}" />
-         <AxisPos Pos="{A1 0.00, A2 60.00, A3 -75.00, A4 0.00, A5 -75.00, A6 0.00}" />
+         <AxisPos Pos="{A1 0.00, A2 -60.00, A3 80.00, A4 0.00, A5 -110.00, A6 0.00}" />
          <ToolData Value="{X 0.00, Y 0.00, Z 0.00, A 0.00, B 0.00, C 0.00}" />
          <BaseData Value="{X 0.00, Y 0.00, Z 0.00, A 0.00, B 0.00, C 0.00}" />
          <ET_AX Value="" />
@@ -62,7 +62,7 @@
          <Type>file.stl.auto</Type>
          <FileRef>../models/table.stl</FileRef>
          <Dimensions Size="1"/>
-         <Position Pos="{X 2675.0000, Y 320.0000, Z 750.0000, A 0.0000, B 0.0000, C 0.0000}"/>
+         <Position Pos="{X 2675.0000, Y 320.0000, Z 2000.0000, A 0.0000, B 0.0000, C 0.0000}"/>
          <Color RGB="#443f7f"/>
          <Display Visible="1" WireFrame="0"/>
          <Attach ToNode="zero"/>

--- a/project/whacAmole.project
+++ b/project/whacAmole.project
@@ -23,7 +23,7 @@
          <MachType></MachType>
          <Link Parent="zero" />
          <Model>KR210-R2700.robot</Model>
-         <Position Pos="{X 4500.00, Y 0.00, Z 0.00, A 180.00, B 0.00, C 0.00}" />
+         <Position Pos="{X 4400.00, Y 0.00, Z 0.00, A 180.00, B 0.00, C 0.00}" />
          <RobRoot Pos="{X 0.00, Y 0.00, Z 0.00, A 0.00, B -0.00, C 0.00}" />
          <AxisPos Pos="{A1 0.00, A2 -60.00, A3 80.00, A4 0.00, A5 -110.00, A6 0.00}" />
          <ToolData Value="{X 0.00, Y 0.00, Z 0.00, A 0.00, B 0.00, C 0.00}" />

--- a/project/whacAmole.project
+++ b/project/whacAmole.project
@@ -67,5 +67,14 @@
          <Display Visible="1" WireFrame="0"/>
          <Attach ToNode="zero"/>
       </Element>
+      <Element>
+         <Info Name="Pedestal"/>
+         <Type>generic.block</Type>
+         <Dimensions X="1000.000" Y="1000.000" Z="1250.000" />
+         <Position Pos="{X -500.0000, Y -500.0000, Z 0.0000, A 0.0000, B 0.0000, C 0.0000}"/>
+         <Color RGB="#804040"/>
+         <Display Visible="1" WireFrame="0"/>
+         <Attach ToNode="zero"/>
+      </Element>
    </Workcell>
 </RobGLProject>


### PR DESCRIPTION
closes #59

Damit der Mole-Roboter jede Position erreichen kann, ohne mit dem Boden oder sich selbst zu kollidieren (das ist offenbar nicht erlaubt), musste ich den Aufbau etwas ändern. Der Table und der Roboter mit dem Hammer sind jetzt höher. 

![image](https://github.com/user-attachments/assets/c1dfa550-fe61-442a-a7db-75d660564605)
